### PR TITLE
fix footnote processing to not output escaped <p> contents

### DIFF
--- a/vendors/ParsedownExtra.php
+++ b/vendors/ParsedownExtra.php
@@ -419,6 +419,7 @@ class ParsedownExtra extends Parsedown
 
             $Element['text'][1]['text'] []= array(
                 'name' => 'li',
+                'handler' => 'text',
                 'attributes' => array('id' => 'fn:'.$definitionId),
                 'text' => "\n".$text."\n",
             );


### PR DESCRIPTION
With this Markdown:

```md
[^foo]: Bar.
```

Before the fix with escaped HTML characters that end up showing the HTML code to visitors:

```php
<div class="footnotes">
<hr />
<ol>
<li id="fn:foo">&lt;p&gt;Bar.&lt;a href="#fnref1:foo" rev="footnote" class="footnote-backref"&gt;↩&lt;/a&gt;&lt;/p&gt;</li>
</ol>
</div>
```

After the fix:

```php
<div class="footnotes">
<hr />
<ol>
<li id="fn:foo"><p>Bar.<a href="#fnref1:foo" rev="footnote" class="footnote-backref">↩</a></p></li>
</ol>
</div>
```